### PR TITLE
Add Dockerfile for biapy/bashembler image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM bash:5.2.15-alpine3.18
+
+COPY --chown=root:root --chmod=755 "bin/bashembler" "/usr/local/bin/bashembler"
+
+RUN mkdir '/data' && \
+  chown 1000:1000 '/data' && \
+  chmod 775 '/data'
+
+SHELL ["/bin/bash", "-c"]
+
+# Entrypoint is bashembler interpreted by bash.
+ENTRYPOINT ["/usr/local/bin/bash", "/usr/local/bin/bashembler"]
+
+# Defualt argument for bashembler is --help to print usage information.
+CMD ["--help"]
+
+# OpenContainers annotations
+# See: https://github.com/opencontainers/image-spec/blob/main/annotations.md
+LABEL "org.opencontainers.image.base.name"="biapy/bashembler"
+LABEL "org.opencontainers.image.title"="Bashembler"
+LABEL "org.opencontainers.image.description"="command-line tool to build a single-file bash script from a\
+  main script sourcing other scripts."
+LABEL "org.opencontainers.image.vendor"="Biapy"
+LABEL "org.opencontainers.image.licenses"="MIT"
+LABEL "org.opencontainers.image.authors"="Pierre-Yves Landuré\
+  - https://github.com/landure\
+  - https://twitter.com/@biapy\
+  - https://howto.biapy.com/"
+LABEL "org.opencontainers.image.source"="https://github.com/biapy/bashembler/"
+LABEL "org.opencontainers.image.docker.run"="docker run --rm --volume '.:/data' 'biapy/bashembler' 'input.sh' 'output.sh'"

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@
 [![CodeFactor](https://www.codefactor.io/repository/github/biapy/bashembler/badge)](https://www.codefactor.io/repository/github/biapy/bashembler)
 
 Bashembler -- contraction for bash-assembler -- aims to ease shell scripts
-development by providing a way to split lenghty scripts in multiple files
+development by providing a way to split lengthy scripts in multiple files
 included by `source` or `.` (dot) instructions, and assembling these files
-in a final one-file script, ready for deployment.
+in a final single-file script, ready for deployment.
+
+[Bashembler @ Docker Hub](https://hub.docker.com/r/biapy/bashembler/).
 
 ## Usage
 
@@ -16,18 +18,26 @@ Process `script.bash` and output the result to `stdout`:
 
 ```bash
 bashembler 'script.bash'
+# Using docker
+docker run --rm --volume '.:/data'  'biapy/bashembler' 'script.bash'
 ```
 
 Process `script.sh` and store result in `bin/script-for-deployment`:
 
 ```bash
-bashembler --output='bin/script-for-deployment' 'script.sh'
+bashembler --output='bin/script-for-deployment' 'script.bash'
+# Using docker
+docker run --rm --volume '.:/data'  'biapy/bashembler' \
+  --output='bin/script-for-deployment' 'script.bash'
 ```
 
-Optionnaly, strip comments from result:
+Optionally, strip comments from result:
 
 ```bash
-bashembler --discard-comments 'script.sh'
+bashembler --discard-comments 'script.bash'
+# Using docker
+docker run --rm --volume '.:/data'  'biapy/bashembler' \
+  --discard-comments 'script.bash'
 ```
 
 ## Third party libraries


### PR DESCRIPTION
Add a Dockerfile based on Bash docker image for publishing Bashembler on Docker Hub.